### PR TITLE
Add option to use unseeded RNG

### DIFF
--- a/habitica_helper/basic_randomizer.py
+++ b/habitica_helper/basic_randomizer.py
@@ -1,0 +1,23 @@
+"""
+A tool for doing basic randomization when StockRandomizer is unavailable.
+"""
+
+import random
+
+
+class BasicRandomizer(object):
+    """
+    A wrapper for python random module that Habitica challenge winners.
+    """
+
+    def pick_integer(self, min_, max_):
+        """
+        Return an integer between min (inclusive) and max (not inclusive).
+
+        The value comes form an uniform distribution, and the seed is based on
+        the stock and date given when initializing the class.
+
+        :min_: Minimum value (inclusive)
+        :max_: Maximum value (not inclusive)
+        """
+        return random.randint(min_, max_)


### PR DESCRIPTION
It seems that the API is fighting yfinance to prevent use, because new errors keep popping up. Thus the fancy logic is disabled for now. This allows reverting to basic RNG instead. Using unseeded RNG means that winner must always be actually awarded together with the message generation, because otherwise the announcement and the actual winner might not match.
